### PR TITLE
release: 🚀 [@isildur-testing/jest]

### DIFF
--- a/.changeset/four-ravens-wink.md
+++ b/.changeset/four-ravens-wink.md
@@ -1,5 +1,0 @@
----
-"@isildur-testing/jest": minor
----
-
-Fixed parsing and transforming test results. This was going wrong before, but will now produce a uniform result no matter if you're running or disovering tests

--- a/.changeset/slimy-adults-fetch.md
+++ b/.changeset/slimy-adults-fetch.md
@@ -1,5 +1,0 @@
----
-"@isildur-testing/jest": patch
----
-
-Bump @isildur-testing/api to version 0.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @isildur-testing/jest
 
+## 0.3.0
+
+### Minor Changes
+
+- 9fd3d83: Fixed parsing and transforming test results. This was going wrong before, but will now produce a uniform result no matter if you're running or disovering tests
+
+### Patch Changes
+
+- 6f379e5: Bump @isildur-testing/api to version 0.2.1
+
 ## 0.2.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@isildur-testing/jest",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "",
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
 - @isildur-testing/jest: [minor] 0.2.0 -> 0.3.0
   - Fixed parsing and transforming test results. This was going wrong before, but will now produce a uniform result no matter if you're running or disovering tests
   - Bump @isildur-testing/api to version 0.2.1